### PR TITLE
Adding non https upload for local unsecured instances

### DIFF
--- a/thingspeak42/thingspeak42.js
+++ b/thingspeak42/thingspeak42.js
@@ -1,4 +1,5 @@
 var https = require('https');
+var http = require('http');
 
 module.exports = function(RED) {
     function ThingSpeak42Node(config) {
@@ -59,16 +60,30 @@ module.exports = function(RED) {
             stopTimer();
 
             node.log("Posting to ThingSpeak: " + url.replace(node.credentials.apiKey, "XXXXXXXXXX"));
-            https.get(url, function(response) {
-                    if(response.statusCode == 200){
-                        node.log("Posted to ThingSpeak");
-                    } else {
-                        node.error("Error posting to ThingSpeak: status code " + response.statusCode);
-                    }
-                }
-            ).on('error', function(e) {
-                node.error("Error posting to ThingSpeak: " + e);
-            });
+			if(url.startsWith("https://")){
+				https.get(url, function(response) {
+						if(response.statusCode == 200){
+							node.log("Posted to ThingSpeak");
+						} else {
+							node.error("Error posting to ThingSpeak: status code " + response.statusCode);
+						}
+					}
+				).on('error', function(e) {
+					node.error("Error posting to ThingSpeak: " + e);
+				});
+			} else {
+				// http access for local unsecured instances
+				http.get(url, function(response) {
+						if(response.statusCode == 200){
+							node.log("Posted to ThingSpeak");
+						} else {
+							node.error("Error posting to ThingSpeak: status code " + response.statusCode);
+						}
+					}
+				).on('error', function(e) {
+					node.error("Error posting to ThingSpeak: " + e);
+				});
+			}
 
             clearStoredValues();
         }


### PR DESCRIPTION
My use case was using a local ThingSpeak install to log data. Said install has no SSL because I don't need it in a local firewalled environment. The node would fail as it's using https to upload data and not http.
So I added the ability to use just http to upload data.